### PR TITLE
container: Use ubi8 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM golang:1.14 AS build
+FROM registry.redhat.io/ubi8/ubi AS build
 WORKDIR /go/src/app
+RUN yum -y install golang make
 COPY go.mod .
 COPY go.sum .
 RUN go mod download


### PR DESCRIPTION
It's better to use ubi8 as the runtime base image, as this image will
already be present and used in the crc bundle, so we can use it for
'free'. We can use it as well for building for better consistency.