### PR TITLE
Export the path used by the vsock client to connect

### DIFF
--- a/cmd/vm/main.go
+++ b/cmd/vm/main.go
@@ -35,7 +35,7 @@ var (
 )
 
 func main() {
-	flag.StringVar(&endpoint, "url", "vsock://2:1024/connect", "url where the tap send packets")
+	flag.StringVar(&endpoint, "url", fmt.Sprintf("vsock://2:1024%s", types.ConnectPath), "url where the tap send packets")
 	flag.StringVar(&iface, "iface", "tap0", "tap interface name")
 	flag.StringVar(&stopIfIfaceExist, "stop-if-exist", "eth0,ens3,enp0s1", "stop if one of these interfaces exists at startup")
 	flag.BoolVar(&debug, "debug", false, "debug")

--- a/pkg/types/paths.go
+++ b/pkg/types/paths.go
@@ -1,0 +1,3 @@
+package types
+
+const ConnectPath = "/connect"

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/code-ready/gvisor-tap-vsock/pkg/types"
 	"github.com/google/tcpproxy"
 	"github.com/sirupsen/logrus"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -26,7 +27,7 @@ func (n *VirtualNetwork) Mux() http.Handler {
 	mux.HandleFunc("/leases", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(n.networkSwitch.IPs.Leases())
 	})
-	mux.HandleFunc("/connect", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(types.ConnectPath, func(w http.ResponseWriter, r *http.Request) {
 		hj, ok := w.(http.Hijacker)
 		if !ok {
 			http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)


### PR DESCRIPTION
This can be use to filter what is accessible from inside the VM via
vsock.

Example:
```
mux := http.NewServeMux()
mux.Handle(types.ConnectPath, vn.Mux())
if err := http.Serve(vsockListener, mux); err != nil {
	errCh <- err
}
```