### PR TITLE
Make IPPool.Leases() concurrency-safe

### DIFF
--- a/pkg/tap/ip_pool.go
+++ b/pkg/tap/ip_pool.go
@@ -24,7 +24,13 @@ func NewIPPool(base *net.IPNet) *IPPool {
 }
 
 func (p *IPPool) Leases() map[string]int {
-	return p.leases
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	leases := map[string]int{}
+	for key, value := range p.leases {
+		leases[key] = value
+	}
+	return leases
 }
 
 func (p *IPPool) Mask() int {


### PR DESCRIPTION
IPPool.Leases is called from http handlers, which runs in their own go
routines, so this could be called concurrently with the other methods
modifying p.leases (Assign/Reserve/Release).
This uses the preexisting 'lock' mutex to ensure exclusive access to
p.leases, and returns a copy rather than the map itself.


Noticed this while reading the code, maybe the methods I mention can never run
concurrently for reasons I missed