### PR TITLE
Defers

### DIFF
--- a/cmd/host/main.go
+++ b/cmd/host/main.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
+	"os"
+	"os/signal"
 	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/code-ready/gvisor-tap-vsock/pkg/transport"
@@ -15,6 +22,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -23,34 +31,77 @@ var (
 	endpoints    arrayFlags
 	vpnkitSocket string
 	qemuSocket   string
+	sshPort      int
+	pidFile      string
+	exitCode     int
 )
 
 func main() {
-	flag.Var(&endpoints, "listen", fmt.Sprintf("url where the tap send packets (default %s)", transport.DefaultURL))
-	flag.BoolVar(&debug, "debug", false, "debug")
-	flag.IntVar(&mtu, "mtu", 1500, "mtu")
+	flag.Var(&endpoints, "listen", fmt.Sprintf("URL where the tap send packets (default %s)", transport.DefaultURL))
+	flag.BoolVar(&debug, "debug", false, "Print debug info")
+	flag.IntVar(&mtu, "mtu", 1500, "Set the MTU")
+	flag.IntVar(&sshPort, "ssh-port", 2222, "Port to access the guest virtual machine. Must be between 1024 and 65535")
 	flag.StringVar(&vpnkitSocket, "listen-vpnkit", "", "VPNKit socket to be used by Hyperkit")
 	flag.StringVar(&qemuSocket, "listen-qemu", "", "Socket to be used by Qemu")
+	flag.StringVar(&pidFile, "pid-file", "", "Generate a file with the PID in it")
 	flag.Parse()
+	ctx, cancel := context.WithCancel(context.Background())
+	// Make this the last defer statement in the stack
+	defer os.Exit(exitCode)
+
+	groupErrs, ctx := errgroup.WithContext(ctx)
+	// Setup signal channel for catching user signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	}
-
 	if len(endpoints) == 0 {
 		endpoints = append(endpoints, transport.DefaultURL)
 	}
-
-	if vpnkitSocket != "" && qemuSocket != "" {
-		log.Fatal("cannot use qemu and vpnkit protocol at the same time")
+	// Make sure the qemu socket provided is valid syntax
+	if len(qemuSocket) > 0 {
+		uri, err := url.Parse(qemuSocket)
+		if err != nil || uri == nil {
+			exitWithError(errors.Wrapf(err, "invalid value for listen-qemu"))
+		}
+		if _, err := os.Stat(uri.Path); err == nil && uri.Scheme == "unix" {
+			exitWithError(errors.Errorf("%q already exists", uri.Path))
+		}
 	}
-
+	if vpnkitSocket != "" && qemuSocket != "" {
+		exitWithError(errors.New("cannot use qemu and vpnkit protocol at the same time"))
+	}
+	// If the given port is not between the privileged ports
+	// and the oft considered maximum port, return an error.
+	if sshPort < 1024 || sshPort > 65535 {
+		exitWithError(errors.New("ssh-port value must be between 1024 and 65535"))
+	}
 	protocol := types.HyperKitProtocol
 	if qemuSocket != "" {
 		protocol = types.QemuProtocol
 	}
 
-	if err := run(&types.Configuration{
+	// Create a PID file if requested
+	if len(pidFile) > 0 {
+		f, err := os.Create(pidFile)
+		if err != nil {
+			exitWithError(err)
+		}
+		// Remove the pid-file when exiting
+		defer func() {
+			if err := os.Remove(pidFile); err != nil {
+				log.Error(err)
+			}
+		}()
+		pid := os.Getpid()
+		if _, err := f.WriteString(strconv.Itoa(pid)); err != nil {
+			exitWithError(err)
+		}
+	}
+
+	config := types.Configuration{
 		Debug:             debug,
 		CaptureFile:       captureFile(),
 		MTU:               mtu,
@@ -92,7 +143,7 @@ func main() {
 			},
 		},
 		Forwards: map[string]string{
-			":2222": "192.168.127.2:22",
+			fmt.Sprintf(":%d", sshPort): "192.168.127.2:22",
 		},
 		NAT: map[string]string{
 			"192.168.127.254": "127.0.0.1",
@@ -102,8 +153,27 @@ func main() {
 			"c3d68012-0208-11ea-9fd7-f2189899ab08": "5a:94:ef:e4:0c:ee",
 		},
 		Protocol: protocol,
-	}, endpoints); err != nil {
-		log.Fatal(err)
+	}
+
+	groupErrs.Go(func() error {
+		return run(ctx, groupErrs, &config, endpoints)
+	})
+
+	// Wait for something to happen
+	groupErrs.Go(func() error {
+		select {
+		// Catch signals so exits are graceful and defers can run
+		case <-sigChan:
+			cancel()
+			return errors.New("signal caught")
+		case <-ctx.Done():
+			return nil
+		}
+	})
+	// Wait for all of the go funcs to finish up
+	if err := groupErrs.Wait(); err != nil {
+		log.Error(err)
+		exitCode = 1
 	}
 }
 
@@ -125,13 +195,12 @@ func captureFile() string {
 	return "capture.pcap"
 }
 
-func run(configuration *types.Configuration, endpoints []string) error {
+func run(ctx context.Context, g *errgroup.Group, configuration *types.Configuration, endpoints []string) error {
 	vn, err := virtualnetwork.New(configuration)
 	if err != nil {
 		return err
 	}
 	log.Info("waiting for clients...")
-	errCh := make(chan error)
 
 	for _, endpoint := range endpoints {
 		log.Infof("listening %s", endpoint)
@@ -139,40 +208,61 @@ func run(configuration *types.Configuration, endpoints []string) error {
 		if err != nil {
 			return errors.Wrap(err, "cannot listen")
 		}
-
-		go func() {
-
-			if err := http.Serve(ln, withProfiler(vn)); err != nil {
-				errCh <- err
+		g.Go(func() error {
+			<-ctx.Done()
+			return ln.Close()
+		})
+		g.Go(func() error {
+			err := http.Serve(ln, withProfiler(vn))
+			if err != nil {
+				if err != http.ErrServerClosed {
+					return err
+				}
+				return err
 			}
-		}()
+			return nil
+		})
 	}
-	go func() {
-		for {
-			fmt.Printf("%v sent to the VM, %v received from the VM\n", humanize.Bytes(vn.BytesSent()), humanize.Bytes(vn.BytesReceived()))
-			time.Sleep(5 * time.Second)
-		}
-	}()
+	if debug {
+		g.Go(func() error {
+		debugLog:
+			for {
+				select {
+				case <-time.After(5 * time.Second):
+					fmt.Printf("%v sent to the VM, %v received from the VM\n", humanize.Bytes(vn.BytesSent()), humanize.Bytes(vn.BytesReceived()))
+				case <-ctx.Done():
+					break debugLog
+				}
+			}
+			return nil
+		})
+	}
 
 	if vpnkitSocket != "" {
 		vpnkitListener, err := transport.Listen(vpnkitSocket)
 		if err != nil {
 			return err
 		}
-		go func() {
+		g.Go(func() error {
+		vpnloop:
 			for {
+				select {
+				case <-ctx.Done():
+					break vpnloop
+				default:
+					// pass through
+				}
 				conn, err := vpnkitListener.Accept()
 				if err != nil {
 					log.Errorf("vpnkit accept error: %s", err)
 					continue
 				}
-				go func() {
-					if err := vn.AcceptVpnKit(conn); err != nil {
-						log.Errorf("vpnkit error: %s", err)
-					}
-				}()
+				g.Go(func() error {
+					return vn.AcceptVpnKit(conn)
+				})
 			}
-		}()
+			return nil
+		})
 	}
 
 	if qemuSocket != "" {
@@ -180,36 +270,39 @@ func run(configuration *types.Configuration, endpoints []string) error {
 		if err != nil {
 			return err
 		}
+
+		g.Go(func() error {
+			<-ctx.Done()
+			if err := qemuListener.Close(); err != nil {
+				log.Errorf("error closing %s: %q", qemuSocket, err)
+			}
+			return os.Remove(qemuSocket)
+		})
+
 		go func() {
 			for {
+				select {
+				case <-ctx.Done():
+					break
+				default:
+					// passthrough
+				}
 				conn, err := qemuListener.Accept()
 				if err != nil {
+					if strings.Contains(err.Error(), "use of closed network connection") {
+						break
+					}
 					log.Errorf("qemu accept error: %s", err)
 					continue
 				}
-				go func() {
-					if err := vn.AcceptQemu(conn); err != nil {
-						log.Errorf("qemu error: %s", err)
-					}
-				}()
+				g.Go(func() error {
+					return vn.AcceptQemu(ctx, conn)
+				})
 			}
 		}()
 	}
 
-	ln, err := vn.Listen("tcp", fmt.Sprintf("%s:8080", configuration.GatewayIP))
-	if err != nil {
-		return err
-	}
-	go func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
-			_, _ = writer.Write([]byte(`Hello world!\n`))
-		})
-		if err := http.Serve(ln, mux); err != nil {
-			errCh <- err
-		}
-	}()
-	return <-errCh
+	return nil
 }
 
 func withProfiler(vn *virtualnetwork.VirtualNetwork) http.Handler {
@@ -221,4 +314,9 @@ func withProfiler(vn *virtualnetwork.VirtualNetwork) http.Handler {
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	}
 	return mux
+}
+
+func exitWithError(err error) {
+	log.Error(err)
+	os.Exit(1)
 }

--- a/go.mod
+++ b/go.mod
@@ -20,5 +20,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gvisor.dev/gvisor v0.0.0-20210424070529-29f85eb7ca69
 )

--- a/pkg/virtualnetwork/mux.go
+++ b/pkg/virtualnetwork/mux.go
@@ -45,7 +45,7 @@ func (n *VirtualNetwork) Mux() *http.ServeMux {
 			return
 		}
 
-		n.networkSwitch.Accept(conn)
+		n.networkSwitch.Accept(context.Background(), conn)
 	})
 	mux.HandleFunc("/tunnel", func(w http.ResponseWriter, r *http.Request) {
 		ip := r.URL.Query().Get("ip")

--- a/pkg/virtualnetwork/qemu.go
+++ b/pkg/virtualnetwork/qemu.go
@@ -1,10 +1,11 @@
 package virtualnetwork
 
 import (
+	"context"
 	"net"
 )
 
-func (n *VirtualNetwork) AcceptQemu(conn net.Conn) error {
-	n.networkSwitch.Accept(conn)
+func (n *VirtualNetwork) AcceptQemu(ctx context.Context, conn net.Conn) error {
+	n.networkSwitch.Accept(ctx, conn)
 	return nil
 }

--- a/pkg/virtualnetwork/vpnkit.go
+++ b/pkg/virtualnetwork/vpnkit.go
@@ -1,6 +1,7 @@
 package virtualnetwork
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"io"
@@ -15,7 +16,7 @@ func (n *VirtualNetwork) AcceptVpnKit(conn net.Conn) error {
 	if err := vpnkitHandshake(conn, n.configuration); err != nil {
 		log.Error(err)
 	}
-	n.networkSwitch.Accept(conn)
+	n.networkSwitch.Accept(context.Background(), conn)
 	return nil
 }
 

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -120,6 +120,9 @@ golang.org/x/net/internal/iana
 golang.org/x/net/internal/socket
 golang.org/x/net/ipv4
 golang.org/x/net/ipv6
+# golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+## explicit
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
Run defers on exit and add cmd line opts
    
Slightly altered the structure for the host binary so that when the  process is killed or control-c'd, it will exit gracefully by running all the defer statements which generally clean up the sockets and pidfiles.
    
Also added command line options for --pid-file, which stores the pid so it can be looked up later, as well as --ssh-port that allows the ssh port to be dynamic (default is 2222).
    
Finally, removed the secondary http server on port 8080.
    
Signed-off-by: Brent Baude <bbaude@redhat.com>
